### PR TITLE
fix: don't mutate collection traits

### DIFF
--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -2530,7 +2530,7 @@ class Plot(PluginSubcomponent):
                                     'y': self.figure.axes[1].scale},
                             colors=kwargs.pop('color', kwargs.pop('colors', 'gray')),
                             **kwargs)
-        self.figure.marks += [mark]
+        self.figure.marks = self.figure.marks + [mark]
         self._marks[label] = mark  # TODO: handle overwriting case
         return mark
 
@@ -2541,7 +2541,7 @@ class Plot(PluginSubcomponent):
                               colors=kwargs.pop('color', kwargs.pop('colors', 'gray')),
                               **kwargs
                               )
-        self.figure.marks += [mark]
+        self.figure.marks = self.figure.marks + [mark]
         self._marks[label] = mark  # TODO: handle overwriting case
         return mark
 


### PR DESCRIPTION
In-place mutations will not be picked up as changes by the traitlet framework. In the popout window the marks were displayed, because the entire state is read when opened.
