### PR TITLE
Disable astrowidgets pixel marking when WCS linked (PR to PR 14 to PR 2179)

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -2391,6 +2391,7 @@ class Application(VuetifyTemplate, HubListener):
             'locked': False,
             'ndims': data.ndim,
             'type': typ,
+            'has_wcs': wcsaxes is not None,
             'meta': {k: v for k, v in data.meta.items() if _expose_meta(k)},
             'children': []}
 

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -1,23 +1,17 @@
 <template>
   <span v-if="icon !== undefined">
-    <v-badge
-      dot
-      style="margin-right: 4px;"
-      color="accent"
-      :value="isRefData()">
     <v-icon v-if="String(icon).startsWith('mdi-')" size="16">
       {{icon}}
     </v-icon>
     <span v-else :class="prevent_invert_if_dark ? 'layer-viewer-icon' : 'invert-if-dark layer-viewer-icon'" :style="span_style+'; color: '+color+'; '+borderStyle">
       {{String(icon).toUpperCase()}}
     </span>
-  </v-badge>
   </span>
 </template>
 
 <script>
 module.exports = {
-  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark', 'is_ref_data', 'linked_by_wcs'],
+  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark'],
   computed: {
     borderStyle() {
       if (this.$props.linewidth > 0) { 
@@ -25,15 +19,6 @@ module.exports = {
       }
       return ''
     },
-  },
-  methods: {
-    isRefData() {
-      if (!this.$props.linked_by_wcs || this.$props.is_ref_data === undefined) {
-        return false
-      } else {
-        return this.$props.is_ref_data
-      }
-    }
   }
 };
 </script>

--- a/jdaviz/components/layer_viewer_icon.vue
+++ b/jdaviz/components/layer_viewer_icon.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="icon !== undefined">
-    <v-icon v-if="String(icon).startsWith('mdi-')" size="16">
+    <v-icon v-if="String(icon).startsWith('mdi-')" :size="icon_size || 16">
       {{icon}}
     </v-icon>
     <span v-else :class="prevent_invert_if_dark ? 'layer-viewer-icon' : 'invert-if-dark layer-viewer-icon'" :style="span_style+'; color: '+color+'; '+borderStyle">
@@ -11,7 +11,7 @@
 
 <script>
 module.exports = {
-  props: ['span_style', 'color', 'icon', 'linewidth', 'linestyle', 'prevent_invert_if_dark'],
+  props: ['span_style', 'color', 'icon', 'icon_size', 'linewidth', 'linestyle', 'prevent_invert_if_dark'],
   computed: {
     borderStyle() {
       if (this.$props.linewidth > 0) { 

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -66,6 +66,7 @@ const tooltips = {
   'viewer-data-radio': 'Switch visibility to layers associated with this data entry',
   'viewer-data-enable': 'Load data entry into this viewer',
   'viewer-data-disable': 'Disable data within this viewer (will be hidden and unavailable from plugins until re-enabled)',
+  'viewer-wcs-delete': 'Remove orientation option across entire app',
   'viewer-data-delete': 'Remove data entry across entire app (might affect existing subsets)',
   'viewer-data-nowcs': 'Data does not have WCS, cannot add unless link type changed to pixel',
 

--- a/jdaviz/components/tooltip.vue
+++ b/jdaviz/components/tooltip.vue
@@ -67,6 +67,7 @@ const tooltips = {
   'viewer-data-enable': 'Load data entry into this viewer',
   'viewer-data-disable': 'Disable data within this viewer (will be hidden and unavailable from plugins until re-enabled)',
   'viewer-data-delete': 'Remove data entry across entire app (might affect existing subsets)',
+  'viewer-data-nowcs': 'Data does not have WCS, cannot add unless link type changed to pixel',
 
   'table-prev': 'Select previous row in table',
   'table-next': 'Select next row in table',

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -58,7 +58,23 @@
           ></j-viewer-data-select-item>
         </v-row>
 
-        <div v-if="extraDataItems.length" style="margin-bottom: -8px;">
+        <div v-if="linkedByWcs()">
+          <j-plugin-section-header style="margin-top: 0px">Orientation</j-plugin-section-header>
+          <v-row v-for="item in wcsOnlyItems" :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
+            <j-viewer-data-select-item
+              :item="item"
+              :icon="layer_icons[item.name]"
+              :viewer="viewer"
+              :multi_select="multi_select"
+              :linked_by_wcs="linkedByWcs()"
+              @data-item-visibility="$emit('data-item-visibility', $event)"
+              @data-item-remove="$emit('data-item-remove', $event)"
+              @change-reference-data="$emit('change-reference-data', $event)"
+            ></j-viewer-data-select-item>
+          </v-row>
+        </div>
+
+        <div v-if="extraDataItems.length > 0" style="margin-bottom: -8px;">
           <v-row key="extra-items-expand" style="padding-left: 25px; margin-right: 0px; padding-bottom: 4px; background-color: #E3F2FD"> 
             <span 
               @click="toggleShowExtraItems"
@@ -75,8 +91,7 @@
             </span>
           </v-row>
 
-          <v-row v-if="showExtraItems" v-for="item in extraDataItems"  :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
-            <div v-if="linkedByWcs()">
+          <v-row v-if="showExtraItems" v-for="item in extraDataItems" :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
             <j-viewer-data-select-item
               :item="item"
               :icon="layer_icons[item.name]"
@@ -88,38 +103,8 @@
               @data-item-remove="$emit('data-item-remove', $event)"
               @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select-item>
-            </div>
           </v-row>
         </div>
-
-        <div v-if="linkedByWcs()" style="margin-bottom: -8px;">
-          <v-row key="wcs-only-items-expand" style="padding-left: 25px; margin-right: 0px; padding-bottom: 4px; background-color: #E3F2FD">
-            <span
-              @click="toggleShowWcsOnlyItems"
-              class='text--primary'
-              style="overflow-wrap: anywhere; font-size: 12pt; padding-top: 6px; padding-left: 6px; cursor: pointer"
-            >
-              <v-icon class='invert-if-dark'>{{showWcsOnlyItems ? 'mdi-chevron-double-up' : 'mdi-chevron-double-down'}}</v-icon>
-              <span>
-                {{showWcsOnlyItems ? 'hide orientation options' : 'show orientation options'}}
-              </span>
-            </span>
-          </v-row>
-
-          <v-row v-if="showWcsOnlyItems" v-for="item in wcsOnlyItems"  :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
-            <j-viewer-data-select-item
-              :item="item"
-              :icon="layer_icons[item.name]"
-              :viewer="viewer"
-              :multi_select="multi_select"
-              :linked_by_wcs="linkedByWcs()"
-              @data-item-visibility="$emit('data-item-visibility', $event)"
-              @data-item-remove="$emit('data-item-remove', $event)"
-              @change-reference-data="$emit('change-reference-data', $event)"
-            ></j-viewer-data-select-item>
-          </v-row>
-        </div>
-
       </v-list>
     </v-menu>
   </j-tooltip>
@@ -150,7 +135,6 @@ module.exports = {
       showExtraItems: false,
       valueTrunc: this.value,
       uncertTrunc: this.uncertainty,
-      showWcsOnlyItems: false
     }
   },
   methods: {
@@ -242,10 +226,6 @@ module.exports = {
           }
         }
       }
-    },
-    toggleShowWcsOnlyItems() {
-      // toggle the visibility of the WCS-only items in the menu
-      this.showWcsOnlyItems = !this.showWcsOnlyItems
     },
     isRefData() {
       return this.$props.item.viewer.reference_data_label === this.$props.item.name

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -49,12 +49,11 @@
             :icon="layer_icons[item.name]"
             :viewer="viewer"
             :multi_select="multi_select"
+            :is_wcs_only="false"
             :n_data_entries="nDataEntries"
-            :linked_by_wcs="linkedByWcs()"
             @data-item-visibility="$emit('data-item-visibility', $event)"
             @data-item-unload="$emit('data-item-unload', $event)"
             @data-item-remove="$emit('data-item-remove', $event)"
-            @change-reference-data="$emit('change-reference-data', $event)"
           ></j-viewer-data-select-item>
         </v-row>
 
@@ -66,8 +65,7 @@
               :icon="layer_icons[item.name]"
               :viewer="viewer"
               :multi_select="multi_select"
-              :linked_by_wcs="linkedByWcs()"
-              @data-item-visibility="$emit('data-item-visibility', $event)"
+              :is_wcs_only="true"
               @data-item-remove="$emit('data-item-remove', $event)"
               @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select-item>
@@ -97,11 +95,10 @@
               :icon="layer_icons[item.name]"
               :viewer="viewer"
               :multi_select="multi_select"
+              :is_wcs_only="false"
               :n_data_entries="nDataEntries"
-              :linked_by_wcs="linkedByWcs()"
               @data-item-visibility="$emit('data-item-visibility', $event)"
               @data-item-remove="$emit('data-item-remove', $event)"
-              @change-reference-data="$emit('change-reference-data', $event)"
             ></j-viewer-data-select-item>
           </v-row>
         </div>

--- a/jdaviz/components/viewer_data_select.vue
+++ b/jdaviz/components/viewer_data_select.vue
@@ -59,7 +59,7 @@
 
         <div v-if="linkedByWcs()">
           <j-plugin-section-header style="margin-top: 0px">Orientation</j-plugin-section-header>
-          <v-row v-for="item in wcsOnlyItems" :key="item.id" style="padding-left: 25px; margin-right: 0px; margin-top: 4px; margin-bottom: 4px">
+          <v-row v-for="item in wcsOnlyItems" :key="item.id" style="padding-left: 25px; margin-right: -8px; margin-top: 4px; margin-bottom: 4px">
             <j-viewer-data-select-item
               :item="item"
               :icon="layer_icons[item.name]"

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -181,7 +181,7 @@ module.exports = {
       isMosviz = this.$props.viewer.config === 'mosviz'
       isCubeviz = this.$props.viewer.config === 'cubeviz'
       isPluginData = !(this.$props.item.meta.Plugin === undefined)
-      return notSelected && (isPluginData || (!isLastDataset && !isMosviz && !isCubeviz))
+      return notSelected && (isPluginData || (!isLastDataset && !isMosviz && !isCubeviz)) && (this.$props.item.name !== 'Default orientation')
     },
     selectTipId() {
       if (this.multi_select) {

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -28,7 +28,7 @@
         </v-btn>
       </j-tooltip>
     </div>
-    <div v-else-if="item.has_wcs">
+    <div v-else-if="!linkedByWcs() || item.has_wcs">
       <j-tooltip tipid="viewer-data-enable">
         <v-btn
           icon

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -1,6 +1,23 @@
 <template>
   <div style="display: contents">
-    <div v-if="isSelected">
+    <div v-if="is_wcs_only">
+      <j-tooltip
+        :tooltipcontent="isRefData() ? 'Current viewer orientation' : 'Set as viewer orientation'"
+        span_style="width: 36px"
+      >
+        <span @click="selectRefData">
+          <v-badge
+            dot
+            style="margin-right: 0px; margin-left: 8px; margin-top: 6px"
+            color="accent"
+            :value="isRefData()"
+          >
+            <j-layer-viewer-icon :icon="icon" icon_size="20" color="#000000DE"></j-layer-viewer-icon>
+          </v-badge>
+        </span>
+      </j-tooltip>
+    </div>
+    <div v-else-if="isSelected">
       <j-tooltip :tipid="multi_select ? 'viewer-data-select' : 'viewer-data-radio'">
         <v-btn 
           icon
@@ -22,21 +39,10 @@
       </j-tooltip>
     </div>
 
-    <j-tooltip
-      :tooltipcontent=dataMenuTooltip
-      span_style="font-size: 12pt; padding-top: 6px; padding-left: 4px; padding-right: 16px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
-    <span
-      :style="dataMenuTooltip !== null ? 'cursor: pointer;' : 'cursor: default;'"
-      @click="selectRefData"
-    >
-      <v-badge
-        dot
-        style="margin-right: 0px;"
-        color="accent"
-        :value="isRefData()"
-      >
-        <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE"></j-layer-viewer-icon>
-      </v-badge>
+    <j-tooltip :tooltipcontent="is_wcs_only ? '' : 'data label: '+item.name" span_style="font-size: 12pt; padding-top: 6px; padding-left: 4px; padding-right: 16px; width: calc(100% - 80px); white-space: nowrap; cursor: default;">
+      <j-layer-viewer-icon v-if="!is_wcs_only" span_style="margin-left: 4px;" :icon="icon" color="#000000DE"></j-layer-viewer-icon>
+      <span v-else style="padding-right: 24px"></span>
+
       <div class="text-ellipsis-middle" style="font-weight: 500;">
         <span>
           {{itemNamePrefix}}
@@ -45,7 +51,6 @@
           {{itemNameExtension}}
         </span>
       </div>
-      </span>
     </j-tooltip>
 
     <div v-if="isSelected && isUnloadable" style="padding-left: 2px; right: 2px">
@@ -74,7 +79,7 @@
 <script>
 
 module.exports = {
-  props: ['item', 'icon', 'multi_select', 'viewer', 'n_data_entries'],
+  props: ['item', 'icon', 'multi_select', 'viewer', 'n_data_entries', 'is_wcs_only'],
   methods: {
     selectClicked() {
       prevVisibleState = this.visibleState
@@ -90,7 +95,7 @@ module.exports = {
       })
     },
     selectRefData() {
-      if (this.linkedByWcs() && !this.isRefData() && this.isWCSOnly()) {
+      if (this.linkedByWcs() && !this.isRefData() && this.is_wcs_only) {
         this.$emit('change-reference-data', {
           id: this.$props.viewer.id,
           item_id: this.$props.item.id
@@ -102,9 +107,6 @@ module.exports = {
     },
     linkedByWcs() {
       return this.$props.viewer.linked_by_wcs
-    },
-    isWCSOnly() {
-      return this.$props.item.type === 'wcs-only'
     }
   },
   computed: {
@@ -183,15 +185,6 @@ module.exports = {
         return 'black'
       } else {
         return 'gray'
-      }
-    },
-    dataMenuTooltip() {
-      if (this.linkedByWcs() && this.$props.viewer.config === 'imviz' && this.isRefData()) {
-        return 'Current viewer orientation'
-      } else if (this.linkedByWcs() && this.$props.viewer.config === 'imviz' && this.$props.item.type === 'wcs-only') {
-        return 'Set viewer orientation'
-      } else {
-        return null
       }
     }
   }

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -76,7 +76,7 @@
     </div>
 
     <div v-if="isDeletable" style="padding-left: 2px; right: 2px">
-      <j-tooltip tipid='viewer-data-delete'>
+      <j-tooltip :tipid="is_wcs_only ? 'viewer-wcs-delete' : 'viewer-data-delete'">
         <v-btn
           icon
           @click="$emit('data-item-remove', {item_name: item.name, viewer_id: viewer.id})"

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -29,7 +29,14 @@
       :style="dataMenuTooltip !== null ? 'cursor: pointer;' : 'cursor: default;'"
       @click="selectRefData"
     >
-      <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE" :is_ref_data="isRefData()" :linked_by_wcs="linkedByWcs()"></j-layer-viewer-icon>
+      <v-badge
+        dot
+        style="margin-right: 0px;"
+        color="accent"
+        :value="isRefData()"
+      >
+        <j-layer-viewer-icon span_style="margin-left: 4px;" :icon="icon" color="#000000DE"></j-layer-viewer-icon>
+      </v-badge>
       <div class="text-ellipsis-middle" style="font-weight: 500;">
         <span>
           {{itemNamePrefix}}

--- a/jdaviz/components/viewer_data_select_item.vue
+++ b/jdaviz/components/viewer_data_select_item.vue
@@ -28,13 +28,23 @@
         </v-btn>
       </j-tooltip>
     </div>
-    <div v-else>
+    <div v-else-if="item.has_wcs">
       <j-tooltip tipid="viewer-data-enable">
         <v-btn
           icon
           color="default"
           @click="selectClicked">
             <v-icon>mdi-plus</v-icon>
+        </v-btn>
+      </j-tooltip>
+    </div>
+    <div v-else>
+      <j-tooltip tipid="viewer-data-nowcs">
+        <v-btn
+          icon
+          color="default"
+          disabled>
+          <v-icon>mdi-plus</v-icon>
         </v-btn>
       </j-tooltip>
     </div>

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -505,6 +505,9 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
         Invalid inputs or reference data.
 
     """
+    # to avoid any confusion with the capitalized-versions in the links control plugin, let's
+    # just always compare against lowercase here.
+    link_type = link_type.lower()
     if len(app.data_collection) <= 1 and link_type != 'wcs':  # No need to link, we are done.
         return
 
@@ -653,10 +656,13 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
 
     app._link_type = link_type
     app._wcs_use_affine = wcs_use_affine
+    # TODO: this all needs to be generalized to work on multiple viewers
+    # (including determining refdata)
     viewer_ref = app._jdaviz_helper.default_viewer.reference
     viewer_item = app._get_viewer_item(viewer_ref)
 
     viewer_item['reference_data_label'] = refdata.label
+    viewer_item['linked_by_wcs'] = link_type == 'wcs'
 
     if link_plugin is not None:
         # Only broadcast after success.

--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -656,13 +656,23 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
 
     app._link_type = link_type
     app._wcs_use_affine = wcs_use_affine
-    # TODO: this all needs to be generalized to work on multiple viewers
-    # (including determining refdata)
-    viewer_ref = app._jdaviz_helper.default_viewer.reference
-    viewer_item = app._get_viewer_item(viewer_ref)
 
-    viewer_item['reference_data_label'] = refdata.label
-    viewer_item['linked_by_wcs'] = link_type == 'wcs'
+    for viewer in app._viewer_store.values():
+        wcs_linked = link_type == 'wcs'
+        # viewer-state needs to know link type for reset_limits behavior
+        viewer.state.linked_by_wcs = wcs_linked
+        # also need to store a copy in the viewer item for the data dropdown to access
+        viewer_item = app._get_viewer_item(viewer.reference)
+
+        viewer_item['reference_data_label'] = refdata.label
+        viewer_item['linked_by_wcs'] = wcs_linked
+
+        if insert_base_wcs_layer:
+            viewer_item['reference_data_label'] = refdata.label
+
+        # if changing from one link type to another, reset the limits:
+        if link_type != old_link_type:
+            viewer.state.reset_limits()
 
     if link_plugin is not None:
         # Only broadcast after success.
@@ -671,22 +681,5 @@ def link_image_data(app, link_type='pixels', wcs_fallback_scheme=None, wcs_use_a
                                              wcs_use_affine,
                                              sender=app))
 
-        if insert_base_wcs_layer:
-            # update all viewer items with reference data:
-            for viewer_id in app.get_viewer_ids():
-                viewer_item = app._get_viewer_item(viewer_id)
-                viewer_item['reference_data_label'] = refdata.label
-
         # reset the progress spinner
         link_plugin.linking_in_progress = False
-
-    for viewer in app._viewer_store.values():
-        wcs_linked = link_type == 'wcs'
-        # viewer-state needs to know link type for reset_limits behavior
-        viewer.state.linked_by_wcs = wcs_linked
-        # also need to store a copy in the viewer item for the data dropdown to access
-        viewer_item['linked_by_wcs'] = wcs_linked
-
-        # if changing from one link type to another, reset the limits:
-        if link_type != old_link_type:
-            viewer.state.reset_limits()

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -16,7 +16,8 @@ from jdaviz.configs.imviz.wcs_utils import (
     get_compass_info, _get_rotated_nddata_from_label
 )
 from jdaviz.core.events import (
-    LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage
+    LinkUpdatedMessage, ExitBatchLoadMessage, MarkersChangedMessage, ChangeRefDataMessage,
+    SnackbarMessage
 )
 from jdaviz.core.custom_traitlets import FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
@@ -214,16 +215,12 @@ class LinksControl(PluginTemplateMixin, ViewerSelectMixin):
             is_wcs_only = data.meta.get(self.app._wcs_only_label, False)
             has_wcs = hasattr(data.coords, 'pixel_to_world')
             if not is_wcs_only:
-                if data not in data_in_viewer:
-                    # add data from viewer:
-                    if wcs_linked and has_wcs:
-                        self.app.add_data_to_viewer(viewer_selected.reference, data.label)
-                    elif not wcs_linked:
-                        self.app.add_data_to_viewer(viewer_selected.reference, data.label)
-
-                elif wcs_linked and not has_wcs:
+                if data in data_in_viewer and wcs_linked and not has_wcs:
                     # data is in viewer but must be removed:
                     self.app.remove_data_from_viewer(viewer_selected.reference, data.label)
+                    self.hub.broadcast(SnackbarMessage(
+                        f"Data '{data.label}' does not have a valid WCS - removing from viewer.",
+                        sender=self, color="warning"))
 
         self.linking_in_progress = False
         self._update_layer_label_default()

--- a/jdaviz/configs/imviz/tests/test_linking.py
+++ b/jdaviz/configs/imviz/tests/test_linking.py
@@ -1,6 +1,7 @@
 import pytest
-from astropy.table import Table
 import astropy.units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
 from astropy.wcs import WCS
 from glue.core.link_helpers import LinkSame
 from glue.plugins.wcs_autolinking.wcs_autolinking import AffineLink, OffsetLink
@@ -119,8 +120,8 @@ class TestLink_WCS_WCS(BaseImviz_WCS_WCS, BaseLinkHandler):
                                  PolygonPixelRegion(vertices=PixCoord(x=[2, 3, 3], y=[2, 2, 3]))])
 
         # Add markers.
-        tbl = Table({'x': (0, 0), 'y': (0, 1)})
-        self.viewer.add_markers(tbl, marker_name='xy_markers')
+        tbl = Table({'coord': [SkyCoord(337.5203, -20.8333, unit="deg")]})
+        self.viewer.add_markers(tbl, use_skycoord=True, marker_name='xy_markers')
         assert 'xy_markers' in self.imviz.app.data_collection.labels
 
         # linking shouldn't be possible now because astrowidgets creates a data entry

--- a/jdaviz/core/astrowidgets_api.py
+++ b/jdaviz/core/astrowidgets_api.py
@@ -473,6 +473,8 @@ class AstrowidgetsImageViewerMixin:
                 jglue.data_collection[marker_name] = t_glue
                 jglue.add_link(t_glue, 'ra', image, ra_str)
                 jglue.add_link(t_glue, 'dec', image, dec_str)
+        elif self.jdaviz_app.config == "imviz" and self.jdaviz_app._link_type == "wcs":
+            raise TypeError("Cannot add markers in pixel space when linked by WCS.")
         else:
             t_glue = Data(marker_name, **table[x_colname, y_colname])
             with jglue.data_collection.delay_link_manager_update():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request is to address adding markers in pixel space breaking when there is rotation layer. Markers added with SkyCoord already satisfies "marks should adjust to a change in orientation layer" (see screenshots below).

This is a PR to:

* bmorris3/jdaviz#14

that is a PR to:

* spacetelescope/jdaviz#2179

I fixed the one test failure I know is caused by my change here. When I ran the full test suite locally, there were several other test failures that look like they are from different parts of the code, but the PR 2179 branch is also outdated compared to latest `main`, so some of those maybe already fixed in `main`, so the PR 2179 branch should be rebased first before fixing the tests.

### Default orientation

<img src="https://github.com/kecnry/jdaviz/assets/2090236/c87a7067-8639-45d9-b964-c3e2f41f28e1" width="400"/>

### N-up E-left

<img src="https://github.com/kecnry/jdaviz/assets/2090236/753aa3fd-7fae-42e0-92ba-53d107444a41" width="400"/>

[🐱](https://jira.stsci.edu/browse/JDAT-3945)