### PR TITLE
Loaders cubeviz

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -779,6 +779,15 @@ class Application(VuetifyTemplate, HubListener):
 
                     # Create link if component-types match
                     if new_comp._component_type == existing_comp._component_type:
+                        # For RA and Dec, need to match the component label not just type
+                        # for configs with image viewers but no Orientation plugin.
+                        ra_labels = ('ra', 'right ascension')
+                        dec_labels = {'dec', 'declination'}
+                        new_lower = new_comp.label.lower()
+                        existing_lower = existing_comp.label.lower()
+                        if ((new_lower in ra_labels and existing_lower not in ra_labels) or
+                                (new_lower in dec_labels and existing_lower not in dec_labels)):
+                            continue
                         msg_text = f"Creating link {new_data.label}:{new_comp.label}({new_comp._component_type}) > {existing_data.label}:{existing_comp.label}({existing_comp._component_type})"  # noqa
                         msg = SnackbarMessage(text=msg_text,
                                               color='info', sender=self)

--- a/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
+++ b/jdaviz/configs/cubeviz/plugins/moment_maps/tests/test_moment_maps.py
@@ -113,7 +113,7 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
     assert len(mv_data) == 1
     assert mv_data[0].label == 'moment 0'
 
-    assert len(dc.links) == 17
+    assert len(dc.links) == 18
 
     # label should remain unchanged but raise overwrite warnings
     assert mm._obj.results_label == 'moment 0'
@@ -155,13 +155,13 @@ def test_moment_calculation(cubeviz_helper, spectrum1d_cube,
     mm._obj.vue_calculate_moment()
 
     assert dc[-1].label == 'moment 1'
-    assert len(dc.links) == 25
-    assert len(dc.external_links) == 5  # pixel linked
+    assert len(dc.links) == 28
+    assert len(dc.external_links) == 6  # world linked
     # Link 3D z to 2D x and 3D y to 2D y
-    assert (dc.external_links[3].cids1[0].label == "Pixel Axis 1 [y]" and
-            dc.external_links[3].cids2[0].label == "Pixel Axis 0 [y]" and
-            dc.external_links[4].cids1[0].label == "Pixel Axis 2 [x]" and
-            dc.external_links[4].cids2[0].label == "Pixel Axis 1 [x]")
+    assert (dc.external_links[3].cids1[0].label == "Declination" and
+            dc.external_links[3].cids2[0].label == "Declination" and
+            dc.external_links[4].cids1[0].label == "Right Ascension" and
+            dc.external_links[4].cids2[0].label == "Right Ascension")
 
     # Coordinate display should be unaffected.
     label_mouseover._viewer_mouse_event(flux_viewer, {'event': 'mousemove',

--- a/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
+++ b/jdaviz/configs/default/plugins/gaussian_smooth/gaussian_smooth.py
@@ -172,9 +172,16 @@ class GaussianSmooth(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
             results = self.spectral_smooth()
 
         if add_data:
+            load_kwargs = {}
+            # Don't auto-extract in Cubeviz
+            if self.config == 'cubeviz' and self.dataset.selected_obj.flux.ndim == 3:
+                load_kwargs['auto_extract'] = False
+                load_kwargs['flux_only'] = True
             # add data to the collection/viewer
             self.add_results.add_results_from_plugin(results,
-                                                     format=('1D Spectrum', '2D Spectrum'))
+                                                     format=('1D Spectrum', '2D Spectrum',
+                                                             '3D Spectrum'),
+                                                     load_kwargs=load_kwargs)
             self._set_default_results_label()
 
         snackbar_message = SnackbarMessage(

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -69,6 +69,8 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
     auto_extract = Bool(True).tag(sync=True)
     function_items = List().tag(sync=True)
     function_selected = Unicode('Sum').tag(sync=True)
+    # Don't load uncertainty and mask as separate cubes, e.g. for plugin results
+    flux_only = Bool(False).tag(sync=True)
 
     # Extracted Data
     ext_data_label_value = Unicode().tag(sync=True)
@@ -211,7 +213,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
 
     @property
     def user_api(self):
-        expose = ['auto_extract', 'ext_data_label', 'ext_viewer']
+        expose = ['auto_extract', 'ext_data_label', 'ext_viewer', 'flux_only']
         if self.has_unc:
             expose += ['unc_data_label', 'unc_viewer']
         if self.has_mask:
@@ -290,7 +292,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
         # TODO: this will need to be removed when removing restriction of a single flux cube
         self.app._jdaviz_helper._loaded_flux_cube = self.app.data_collection[data_label]
 
-        if self.has_unc:
+        if self.has_unc and not self.flux_only:
             # TODO: detect if uncertainty exists and hide section from UI
             uncert = Spectrum(spectral_axis=self.output.spectral_axis,
                               flux=self.output.uncertainty.represent_as(StdDevUncertainty).quantity,
@@ -303,7 +305,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
             # TODO: this will need to be removed when removing restriction of a single flux cube
             self.app._jdaviz_helper._loaded_uncert_cube = self.app.data_collection[unc_data_label]
 
-        if self.has_mask:
+        if self.has_mask and not self.flux_only:
             mask = Spectrum(spectral_axis=self.output.spectral_axis,
                             flux=self.output.mask * u.dimensionless_unscaled,
                             wcs=self.output.wcs,

--- a/jdaviz/core/loaders/importers/spectrum_common.py
+++ b/jdaviz/core/loaders/importers/spectrum_common.py
@@ -167,8 +167,8 @@ class SpectrumInputExtensionsMixin(VuetifyTemplate, HubListener):
         # Kept for posterity in for data processed prior to this date. Use EXP_TYPE instead
         filetype = metadata[PRIHDR_KEY].get('FILETYPE', '').lower()
         if telescop == 'jwst' and ('ifu' in exptype or
-                                    'mrs' in exptype or
-                                    filetype == '3d ifu cube'):
+                                   'mrs' in exptype or
+                                   filetype == '3d ifu cube'):
             from stdatamodels import asdf_in_fits
             tree = asdf_in_fits.open(hdulist).tree
             if 'meta' in tree and 'wcs' in tree['meta']:

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -4610,7 +4610,8 @@ class AddResults(BasePluginComponent):
         self.label_invalid_msg = ''
         self.label_overwrite = False
 
-    def add_results_from_plugin(self, data_item, replace=None, label=None, format=None):
+    def add_results_from_plugin(self, data_item, replace=None, label=None, format=None,
+                                load_kwargs={}):
         """
         Add ``data_item`` to the app's data_collection according to the default or user-provided
         label and adds to any requested viewers.
@@ -4678,7 +4679,7 @@ class AddResults(BasePluginComponent):
         if self.app.config in CONFIGS_WITH_LOADERS and format is not None:
             self.app._jdaviz_helper.load(data_item,
                                          loader='object', format=format,
-                                         data_label=label, viewer=[])
+                                         data_label=label, viewer=[], **load_kwargs)
         else:
             # NOTE: eventually remove this entirely once all plugins are set to go through
             # the new loaders infrastructure above


### PR DESCRIPTION
Further work on cubeviz loaders. Looks like I need to rebase to main, I'll do that shortly. So far I've mainly debugged loading the JWST cubes properly, it looks like the next bug to work out is that images (e.g. from plugin results) aren't getting linked properly by the new physical type linking, because Cubeviz doesn't have an Orientation plugin to offload that to.