### PR TITLE
create rules for spatial component types

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -790,15 +790,6 @@ class Application(VuetifyTemplate, HubListener):
 
                     # Create link if component-types match
                     if new_comp._component_type == existing_comp._component_type:
-                        # For RA and Dec, need to match the component label not just type
-                        # for configs with image viewers but no Orientation plugin.
-                        ra_labels = ('ra', 'right ascension')
-                        dec_labels = {'dec', 'declination'}
-                        new_lower = new_comp.label.lower()
-                        existing_lower = existing_comp.label.lower()
-                        if ((new_lower in ra_labels and existing_lower not in ra_labels) or
-                                (new_lower in dec_labels and existing_lower not in dec_labels)):
-                            continue
                         msg_text = f"Creating link {new_data.label}:{new_comp.label}({new_comp._component_type}) > {existing_data.label}:{existing_comp.label}({existing_comp._component_type})"  # noqa
                         msg = SnackbarMessage(text=msg_text,
                                               color='info', sender=self)

--- a/jdaviz/configs/default/plugins/collapse/collapse.py
+++ b/jdaviz/configs/default/plugins/collapse/collapse.py
@@ -105,7 +105,7 @@ class Collapse(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixi
         else:
             w = data.coords
         if isinstance(w, GWCS):
-            data_wcs =  WCS(w.to_fits_sip())
+            data_wcs = WCS(w.to_fits_sip())
         else:
             data_wcs = getattr(w, 'celestial', None)
 

--- a/jdaviz/core/loaders/importers/catalog/catalog.py
+++ b/jdaviz/core/loaders/importers/catalog/catalog.py
@@ -8,6 +8,7 @@ from jdaviz.core.loaders.importers import BaseImporterToDataCollection
 from jdaviz.core.template_mixin import SelectPluginComponent
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.user_api import ImporterUserApi
+from jdaviz.utils import RA_COMPS, DEC_COMPS
 
 __all__ = ['CatalogImporter']
 
@@ -96,15 +97,9 @@ class CatalogImporter(BaseImporterToDataCollection):
             get_idx = lambda x, s, d: np.where(np.isin(x, s))[0][0] if np.any(np.isin(x, s)) else d  # noqa
 
             if col == 'ra':
-                col_possibilities = ['right ascension', 'ra', 'ra_deg', 'radeg',
-                                     'radegrees', 'right ascension (degrees)',
-                                     'ra_obj', 'raj2000', 'ra2000']
-                idx = get_idx(all_column_names, col_possibilities, 0)
+                idx = get_idx(all_column_names, RA_COMPS, 0)
             elif col == 'dec':
-                col_possibilities = ['declination', 'dec', 'dec_deg', 'decdeg',
-                                     'decdegrees', 'declination (degrees)',
-                                     'dec_obj', 'obj_dec', 'decj2000', 'dec2000']
-                idx = get_idx(all_column_names, col_possibilities, 1)
+                idx = get_idx(all_column_names, DEC_COMPS, 1)
 
         return colnames if idx == 0 else (colnames[idx:] + colnames[:idx])
 

--- a/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
+++ b/jdaviz/core/loaders/importers/spectrum3d/spectrum3d.py
@@ -9,6 +9,8 @@ from jdaviz.core.events import SnackbarMessage
 from jdaviz.core.registries import loader_importer_registry, viewer_registry
 from jdaviz.core.loaders.importers import (BaseImporterToDataCollection,
                                            SpectrumInputExtensionsMixin)
+from jdaviz.core.loaders.importers.spectrum_common import _spectrum_assign_component_type
+from jdaviz.core.loaders.importers.image.image import _spatial_assign_component_type
 from jdaviz.core.template_mixin import (AutoTextField,
                                         SelectPluginComponent,
                                         ViewerSelectCreateNew)
@@ -346,3 +348,7 @@ class Spectrum3DImporter(BaseImporterToDataCollection, SpectrumInputExtensionsMi
 
         if ext is not None:
             self.add_to_data_collection(ext, ext_data_label, viewer_select=self.ext_viewer)
+
+    def assign_component_type(self, comp_id, comp, units, physical_type):
+        comp_type = _spatial_assign_component_type(comp_id, comp, units, physical_type)
+        return _spectrum_assign_component_type(comp_id, comp, units, comp_type)

--- a/jdaviz/utils.py
+++ b/jdaviz/utils.py
@@ -43,7 +43,8 @@ __all__ = ['SnackbarQueue', 'enable_hot_reloading', 'bqplot_clear_figure',
            'get_wcs_only_layer_labels', 'get_top_layer_index',
            'get_reference_image_data', 'standardize_roman_metadata',
            'wildcard_match', 'cmap_samples', 'glue_colormaps',
-           'att_to_componentid']
+           'att_to_componentid',
+           'RA_COMPS', 'DEC_COMPS', 'SPECTRAL_AXIS_COMP_LABELS']
 
 NUMPY_LT_2_0 = not minversion("numpy", "2.0.dev")
 STDATAMODELS_LT_402 = not minversion(stdatamodels, "4.0.2.dev")
@@ -59,6 +60,12 @@ SPECTRAL_AXIS_COMP_LABELS = ('Wavelength', 'Wave', 'Frequency', 'Energy',
                              'Velocity', 'Wavenumber',
                              'World 0', 'World 1',
                              'Pixel Axis 0 [x]', 'Pixel Axis 1 [x]')
+RA_COMPS = ['right ascension', 'ra', 'ra_deg', 'radeg',
+            'radegrees', 'right ascension (degrees)',
+            'ra_obj', 'raj2000', 'ra2000']
+DEC_COMPS = ['declination', 'dec', 'dec_deg', 'decdeg',
+             'decdegrees', 'declination (degrees)',
+             'dec_obj', 'obj_dec', 'decj2000', 'dec2000']
 
 
 class SnackbarQueue:


### PR DESCRIPTION
This PR creates custom component types in image and spectrum3d importers to handle spatial axes (sky and pixel).